### PR TITLE
Build with older Java 7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, windows-2019]
-        java: [6, 7, 8, 9, 10]
+        java: [6, 7, 7.0.121, 8, 9, 10]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Java 7 supports TLS 1.2 but it is disabled by default in versions before 1.7.0_131-b31.

Reference: https://github.com/saeg/asm-defuse/pull/3