### PR TITLE
Remove Coveralls integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # ba-dua
 
-[![Coverage Status](https://img.shields.io/coveralls/saeg/ba-dua.svg?style=flat-square)](https://coveralls.io/r/saeg/ba-dua)
 [![Maven Central](https://img.shields.io/maven-central/v/br.usp.each.saeg/ba-dua.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/br.usp.each.saeg/ba-dua)
 [![License](https://img.shields.io/github/license/saeg/ba-dua.svg?style=flat-square)](LICENSE)
 [![DOI](https://zenodo.org/badge/4232/saeg/ba-dua.svg?style=flat-square)](http://dx.doi.org/10.5281/zenodo.11006)

--- a/pom.xml
+++ b/pom.xml
@@ -211,16 +211,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.eluder.coveralls</groupId>
-				<artifactId>coveralls-maven-plugin</artifactId>
-				<version>3.2.1</version>
-				<configuration>
-					<jacocoReports>
-						<jacocoReport>ba-dua-tests/target/site/jacoco-aggregate/jacoco.xml</jacocoReport>
-					</jacocoReports>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jxr-plugin</artifactId>
 				<version>2.5</version>


### PR DESCRIPTION
We are not using Coveralls since we removed Travis integration (39aa509)

Also, coveralls-maven-plugin isn't working with most newer Java versions

Reference: https://github.com/saeg/asm-defuse/pull/11