### PR TITLE
Decouples Agent, RT and CoverageTransformer

### DIFF
--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/CoverageTransformer.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/CoverageTransformer.java
@@ -19,11 +19,12 @@ import br.usp.each.saeg.badua.core.instr.Instrumenter;
 
 public class CoverageTransformer implements ClassFileTransformer {
 
-    private final static String BADUA_PACKAGE = RT.class.getPackage().getName().replace('.', '/');
+    private final String skipPackageName;
 
     private final Instrumenter instrumenter;
 
-    public CoverageTransformer(final String runtime) {
+    public CoverageTransformer(final String runtime, final String skipPackageName) {
+        this.skipPackageName = skipPackageName.replace('.', '/');
         instrumenter = new Instrumenter(runtime,
                 Boolean.valueOf(System.getProperty("badua.experimental.exception_handler")));
     }
@@ -51,7 +52,7 @@ public class CoverageTransformer implements ClassFileTransformer {
         return loader == null
                 || loader.getClass().getName().equals("sun.reflect.DelegatingClassLoader")
                 || loader.getClass().getName().equals("sun.misc.Launcher$ExtClassLoader")
-                || className.startsWith(BADUA_PACKAGE);
+                || className.startsWith(skipPackageName);
     }
 
 }

--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/CoverageTransformer.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/CoverageTransformer.java
@@ -23,8 +23,8 @@ public class CoverageTransformer implements ClassFileTransformer {
 
     private final Instrumenter instrumenter;
 
-    public CoverageTransformer() {
-        instrumenter = new Instrumenter(RT.class.getName(),
+    public CoverageTransformer(final String runtime) {
+        instrumenter = new Instrumenter(runtime,
                 Boolean.valueOf(System.getProperty("badua.experimental.exception_handler")));
     }
 

--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
@@ -20,7 +20,7 @@ public final class PreMain {
 
     public static void premain(final String opts, final Instrumentation inst) {
         RT.init(Agent.getInstance().getData());
-        inst.addTransformer(new CoverageTransformer(RT.class.getName()));
+        inst.addTransformer(new CoverageTransformer(RT.class.getName(), RT.class.getPackage().getName()));
     }
 
 }

--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
@@ -19,7 +19,7 @@ public final class PreMain {
     }
 
     public static void premain(final String opts, final Instrumentation inst) {
-        RT.init();
+        RT.init(Agent.getInstance().getData());
         inst.addTransformer(new CoverageTransformer());
     }
 

--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
@@ -20,7 +20,7 @@ public final class PreMain {
 
     public static void premain(final String opts, final Instrumentation inst) {
         RT.init(Agent.getInstance().getData());
-        inst.addTransformer(new CoverageTransformer());
+        inst.addTransformer(new CoverageTransformer(RT.class.getName()));
     }
 
 }

--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/RT.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/RT.java
@@ -20,10 +20,6 @@ public final class RT {
         // No instances
     }
 
-    public static void init() {
-        init(Agent.getInstance().getData());
-    }
-
     public static void init(final RuntimeData data) {
         DATA = data;
     }

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/instr/Instrumenter.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/instr/Instrumenter.java
@@ -31,10 +31,6 @@ public class Instrumenter {
 
     private final boolean exceptionHandler;
 
-    public Instrumenter(final Class<?> runtime) {
-        this(runtime.getName());
-    }
-
     public Instrumenter(final String runtime) {
         this(runtime, false);
     }

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/ClassInstrumenter.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/ClassInstrumenter.java
@@ -32,10 +32,6 @@ public class ClassInstrumenter extends ClassVisitor implements IdGenerator {
 
     private int classProbeCount;
 
-    public ClassInstrumenter(final long classId, final ClassVisitor cv, final Class<?> runtime) {
-        this(classId, cv, runtime.getName(), false);
-    }
-
     public ClassInstrumenter(final long classId, final ClassVisitor cv, final String runtime) {
         this(classId, cv, runtime, false);
     }


### PR DESCRIPTION
Following the plan to allow different mechanisms to provide the execution data array, this pull request decouples (remove any reference to) `Agent` class from `RT` class and decouples `RT` class from `CoverageTransformer` classes.

In order to keep decoupling, the following constructors (that were supposed to not be used since a46127e) were removed: 

```java
Instrumenter(Class<?> runtime);
ClassInstrumenter(long classId, ClassVisitor cv, Class<?> runtime);
```