### PR TITLE
Extract IExecutionDataAccessorGenerator interface with StaticAccessGenerator implementation

### DIFF
--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/CoverageTransformer.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/CoverageTransformer.java
@@ -16,6 +16,7 @@ import java.lang.instrument.IllegalClassFormatException;
 import java.security.ProtectionDomain;
 
 import br.usp.each.saeg.badua.core.instr.Instrumenter;
+import br.usp.each.saeg.badua.core.runtime.IExecutionDataAccessorGenerator;
 
 public class CoverageTransformer implements ClassFileTransformer {
 
@@ -23,9 +24,10 @@ public class CoverageTransformer implements ClassFileTransformer {
 
     private final Instrumenter instrumenter;
 
-    public CoverageTransformer(final String runtime, final String skipPackageName) {
+    public CoverageTransformer(
+            final IExecutionDataAccessorGenerator accessorGenerator, final String skipPackageName) {
         this.skipPackageName = skipPackageName.replace('.', '/');
-        instrumenter = new Instrumenter(runtime,
+        instrumenter = new Instrumenter(accessorGenerator,
                 Boolean.valueOf(System.getProperty("badua.experimental.exception_handler")));
     }
 

--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
@@ -12,6 +12,8 @@ package br.usp.each.saeg.badua.agent.rt.internal;
 
 import java.lang.instrument.Instrumentation;
 
+import br.usp.each.saeg.badua.core.runtime.StaticAccessGenerator;
+
 public final class PreMain {
 
     private PreMain() {
@@ -20,7 +22,8 @@ public final class PreMain {
 
     public static void premain(final String opts, final Instrumentation inst) {
         RT.init(Agent.getInstance().getData());
-        inst.addTransformer(new CoverageTransformer(RT.class.getName(), RT.class.getPackage().getName()));
+        inst.addTransformer(new CoverageTransformer(
+                new StaticAccessGenerator(RT.class.getName()), RT.class.getPackage().getName()));
     }
 
 }

--- a/ba-dua-cli/src/main/java/br/usp/each/saeg/badua/cli/Instrument.java
+++ b/ba-dua-cli/src/main/java/br/usp/each/saeg/badua/cli/Instrument.java
@@ -26,6 +26,7 @@ import org.kohsuke.args4j.CmdLineParser;
 
 import br.usp.each.saeg.badua.agent.rt.internal.Offline;
 import br.usp.each.saeg.badua.core.instr.Instrumenter;
+import br.usp.each.saeg.badua.core.runtime.StaticAccessGenerator;
 import br.usp.each.saeg.commons.io.Files;
 import br.usp.each.saeg.commons.time.TimeWatch;
 
@@ -40,7 +41,7 @@ public class Instrument {
     public Instrument(final InstrumentOptions options) {
         this.src = options.getSource();
         this.dest = options.getDestination();
-        instrumenter = new Instrumenter(Offline.class.getName(),
+        instrumenter = new Instrumenter(new StaticAccessGenerator(Offline.class.getName()),
                 Boolean.valueOf(System.getProperty("badua.experimental.exception_handler")));
     }
 

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/instr/Instrumenter.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/instr/Instrumenter.java
@@ -21,29 +21,31 @@ import org.objectweb.asm.ClassWriter;
 
 import br.usp.each.saeg.badua.core.internal.data.CRC64;
 import br.usp.each.saeg.badua.core.internal.instr.ClassInstrumenter;
+import br.usp.each.saeg.badua.core.runtime.IExecutionDataAccessorGenerator;
 import br.usp.each.saeg.commons.io.Files;
 
 public class Instrumenter {
 
     private static final int DEFAULT = 0;
 
-    private final String runtime;
+    private final IExecutionDataAccessorGenerator accessorGenerator;
 
     private final boolean exceptionHandler;
 
-    public Instrumenter(final String runtime) {
-        this(runtime, false);
+    public Instrumenter(final IExecutionDataAccessorGenerator accessorGenerator) {
+        this(accessorGenerator, false);
     }
 
-    public Instrumenter(final String runtime, final boolean exceptionHandler) {
-        this.runtime = runtime;
+    public Instrumenter(
+            final IExecutionDataAccessorGenerator accessorGenerator, final boolean exceptionHandler) {
+        this.accessorGenerator = accessorGenerator;
         this.exceptionHandler = exceptionHandler;
     }
 
     public byte[] instrument(final ClassReader reader) {
         final long classId = CRC64.checksum(reader.b);
         final ClassWriter writer = new ClassWriter(reader, DEFAULT);
-        final ClassVisitor ci = new ClassInstrumenter(classId, writer, runtime, exceptionHandler);
+        final ClassVisitor ci = new ClassInstrumenter(classId, writer, accessorGenerator, exceptionHandler);
         reader.accept(ci, ClassReader.EXPAND_FRAMES);
         return writer.toByteArray();
     }

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/ClassInstrumenter.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/ClassInstrumenter.java
@@ -17,6 +17,7 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
 import br.usp.each.saeg.badua.core.runtime.IExecutionDataAccessorGenerator;
+import br.usp.each.saeg.badua.core.runtime.StaticAccessGenerator;
 
 public class ClassInstrumenter extends ClassVisitor implements IdGenerator {
 
@@ -45,24 +46,7 @@ public class ClassInstrumenter extends ClassVisitor implements IdGenerator {
         this.classId = classId;
         this.exceptionHandler = exceptionHandler;
 
-        accessorGenerator = new IExecutionDataAccessorGenerator() {
-
-            @Override
-            public int generateDataAccessor(
-                    final long classId, final String className, final int size, final MethodVisitor mv) {
-
-                mv.visitLdcInsn(classId);
-                mv.visitLdcInsn(className);
-                InstrSupport.push(mv, size);
-                mv.visitMethodInsn(Opcodes.INVOKESTATIC,
-                        runtime.replace('.', '/'),
-                        InstrSupport.RUNTIME_NAME,
-                        InstrSupport.RUNTIME_DESC,
-                        false);
-
-                return 4;
-            }
-        };
+        accessorGenerator = new StaticAccessGenerator(runtime);
     }
 
     @Override

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/ClassInstrumenter.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/ClassInstrumenter.java
@@ -17,7 +17,6 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
 import br.usp.each.saeg.badua.core.runtime.IExecutionDataAccessorGenerator;
-import br.usp.each.saeg.badua.core.runtime.StaticAccessGenerator;
 
 public class ClassInstrumenter extends ClassVisitor implements IdGenerator {
 
@@ -35,18 +34,19 @@ public class ClassInstrumenter extends ClassVisitor implements IdGenerator {
 
     private int classProbeCount;
 
-    public ClassInstrumenter(final long classId, final ClassVisitor cv, final String runtime) {
-        this(classId, cv, runtime, false);
+    public ClassInstrumenter(final long classId, final ClassVisitor cv,
+            final IExecutionDataAccessorGenerator accessorGenerator) {
+        this(classId, cv, accessorGenerator, false);
     }
 
-    public ClassInstrumenter(final long classId, final ClassVisitor cv, final String runtime,
+    public ClassInstrumenter(final long classId, final ClassVisitor cv,
+            final IExecutionDataAccessorGenerator accessorGenerator,
             final boolean exceptionHandler) {
 
         super(Opcodes.ASM6, cv);
         this.classId = classId;
+        this.accessorGenerator = accessorGenerator;
         this.exceptionHandler = exceptionHandler;
-
-        accessorGenerator = new StaticAccessGenerator(runtime);
     }
 
     @Override

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/IExecutionDataAccessorGenerator.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/IExecutionDataAccessorGenerator.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2014, 2020 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.badua.core.runtime;
+
+import org.objectweb.asm.MethodVisitor;
+
+public interface IExecutionDataAccessorGenerator {
+
+    int generateDataAccessor(long classId, String className, int size, MethodVisitor mv);
+
+}

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/StaticAccessGenerator.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/StaticAccessGenerator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2014, 2020 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.badua.core.runtime;
+
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import br.usp.each.saeg.badua.core.internal.instr.InstrSupport;
+
+public class StaticAccessGenerator implements IExecutionDataAccessorGenerator {
+
+    private final String runtime;
+
+    public StaticAccessGenerator(final String runtime) {
+        this.runtime = runtime;
+    }
+
+    @Override
+    public int generateDataAccessor(
+            final long classId, final String className, final int size, final MethodVisitor mv) {
+
+        mv.visitLdcInsn(classId);
+        mv.visitLdcInsn(className);
+        InstrSupport.push(mv, size);
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                runtime.replace('.', '/'),
+                InstrSupport.RUNTIME_NAME,
+                InstrSupport.RUNTIME_DESC,
+                false);
+
+        return 4;
+    }
+
+}

--- a/ba-dua-tests/src/test/java/br/usp/each/saeg/badua/test/validation/ValidationTest.java
+++ b/ba-dua-tests/src/test/java/br/usp/each/saeg/badua/test/validation/ValidationTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 
 import br.usp.each.saeg.badua.agent.rt.internal.RT;
 import br.usp.each.saeg.badua.core.instr.Instrumenter;
+import br.usp.each.saeg.badua.core.runtime.StaticAccessGenerator;
 
 public abstract class ValidationTest {
 
@@ -30,7 +31,8 @@ public abstract class ValidationTest {
     }
 
     private byte[] instrument(final String name, final byte[] bytes) {
-        final Instrumenter instrumenter = new Instrumenter(RT.class.getName(), exceptionHandler);
+        final Instrumenter instrumenter = new Instrumenter(
+                new StaticAccessGenerator(RT.class.getName()), exceptionHandler);
 
         try {
             return instrumenter.instrument(bytes, name);


### PR DESCRIPTION
The instrumented classes need a piece of code that obtains a `long[]` instance from the runtime. The 
 `IExecutionDataAccessorGenerator` interface abstract the code generation for that.

The default implementation didn't change and is named `StaticAccessGenerator`. It creates a static call to a method:

```java
long[] getData(long classId, String className, int size);
```

The owner class can be defined at runtime. Agent instrumentation uses class `RT` and offline instrumentation uses class `Offline`.

The following changes will permit injection of `IExecutionDataAccessorGenerator` implementations at runtime.