### PR TITLE
Extracted the IRuntime interface and make RT implement it

### DIFF
--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
@@ -12,7 +12,7 @@ package br.usp.each.saeg.badua.agent.rt.internal;
 
 import java.lang.instrument.Instrumentation;
 
-import br.usp.each.saeg.badua.core.runtime.StaticAccessGenerator;
+import br.usp.each.saeg.badua.core.runtime.IRuntime;
 
 public final class PreMain {
 
@@ -21,9 +21,9 @@ public final class PreMain {
     }
 
     public static void premain(final String opts, final Instrumentation inst) {
-        RT.init(Agent.getInstance().getData());
-        inst.addTransformer(new CoverageTransformer(
-                new StaticAccessGenerator(RT.class.getName()), RT.class.getPackage().getName()));
+        final IRuntime runtime = new RT();
+        runtime.startup(Agent.getInstance().getData());
+        inst.addTransformer(new CoverageTransformer(runtime, PreMain.class.getPackage().getName()));
     }
 
 }

--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/RT.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/RT.java
@@ -10,14 +10,21 @@
  */
 package br.usp.each.saeg.badua.agent.rt.internal;
 
+import br.usp.each.saeg.badua.core.runtime.IRuntime;
 import br.usp.each.saeg.badua.core.runtime.RuntimeData;
+import br.usp.each.saeg.badua.core.runtime.StaticAccessGenerator;
 
-public final class RT {
+public final class RT extends StaticAccessGenerator implements IRuntime {
 
     private static RuntimeData DATA;
 
-    private RT() {
-        // No instances
+    public RT() {
+        super(RT.class.getName());
+    }
+
+    @Override
+    public void startup(final RuntimeData data) {
+        init(data);
     }
 
     public static void init(final RuntimeData data) {

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/IRuntime.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/IRuntime.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2014, 2020 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.badua.core.runtime;
+
+public interface IRuntime extends IExecutionDataAccessorGenerator {
+
+    void startup(RuntimeData data);
+
+}


### PR DESCRIPTION
Following the plan to allow different mechanisms to provide the execution data array, normally, the mechanism are runtime specific and abstracted by the interface `IExecutionDataAccessorGenerator`.

Implementations are provided by `IRuntime` interface implementations and are used by the instrumentation process. This interface represents a particular mechanism to collect execution information in the target VM at runtime.