### PR TITLE
Enable `CatchAndThrowMethodVisitor` by default

### DIFF
--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/CoverageTransformer.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/CoverageTransformer.java
@@ -27,8 +27,7 @@ public class CoverageTransformer implements ClassFileTransformer {
     public CoverageTransformer(
             final IExecutionDataAccessorGenerator accessorGenerator, final String skipPackageName) {
         this.skipPackageName = skipPackageName.replace('.', '/');
-        instrumenter = new Instrumenter(accessorGenerator,
-                Boolean.valueOf(System.getProperty("badua.experimental.exception_handler")));
+        instrumenter = new Instrumenter(accessorGenerator);
     }
 
     @Override

--- a/ba-dua-cli/src/main/java/br/usp/each/saeg/badua/cli/Instrument.java
+++ b/ba-dua-cli/src/main/java/br/usp/each/saeg/badua/cli/Instrument.java
@@ -41,8 +41,7 @@ public class Instrument {
     public Instrument(final InstrumentOptions options) {
         this.src = options.getSource();
         this.dest = options.getDestination();
-        instrumenter = new Instrumenter(new StaticAccessGenerator(Offline.class.getName()),
-                Boolean.valueOf(System.getProperty("badua.experimental.exception_handler")));
+        instrumenter = new Instrumenter(new StaticAccessGenerator(Offline.class.getName()));
     }
 
     public int instrument() throws IOException {

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/instr/Instrumenter.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/instr/Instrumenter.java
@@ -30,22 +30,14 @@ public class Instrumenter {
 
     private final IExecutionDataAccessorGenerator accessorGenerator;
 
-    private final boolean exceptionHandler;
-
     public Instrumenter(final IExecutionDataAccessorGenerator accessorGenerator) {
-        this(accessorGenerator, false);
-    }
-
-    public Instrumenter(
-            final IExecutionDataAccessorGenerator accessorGenerator, final boolean exceptionHandler) {
         this.accessorGenerator = accessorGenerator;
-        this.exceptionHandler = exceptionHandler;
     }
 
     public byte[] instrument(final ClassReader reader) {
         final long classId = CRC64.checksum(reader.b);
         final ClassWriter writer = new ClassWriter(reader, DEFAULT);
-        final ClassVisitor ci = new ClassInstrumenter(classId, writer, accessorGenerator, exceptionHandler);
+        final ClassVisitor ci = new ClassInstrumenter(classId, writer, accessorGenerator);
         reader.accept(ci, ClassReader.EXPAND_FRAMES);
         return writer.toByteArray();
     }

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/ClassInstrumenter.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/ClassInstrumenter.java
@@ -24,8 +24,6 @@ public class ClassInstrumenter extends ClassVisitor implements IdGenerator {
 
     private final IExecutionDataAccessorGenerator accessorGenerator;
 
-    private final boolean exceptionHandler;
-
     private String className;
 
     private boolean withFrames;
@@ -36,17 +34,10 @@ public class ClassInstrumenter extends ClassVisitor implements IdGenerator {
 
     public ClassInstrumenter(final long classId, final ClassVisitor cv,
             final IExecutionDataAccessorGenerator accessorGenerator) {
-        this(classId, cv, accessorGenerator, false);
-    }
-
-    public ClassInstrumenter(final long classId, final ClassVisitor cv,
-            final IExecutionDataAccessorGenerator accessorGenerator,
-            final boolean exceptionHandler) {
 
         super(Opcodes.ASM6, cv);
         this.classId = classId;
         this.accessorGenerator = accessorGenerator;
-        this.exceptionHandler = exceptionHandler;
     }
 
     @Override
@@ -106,9 +97,8 @@ public class ClassInstrumenter extends ClassVisitor implements IdGenerator {
 
         // There is some edge cases with constructors and stack map frames
         // So we will ignore constructors. We must address these issues in the future
-        return exceptionHandler && !name.equals("<init>")
-                ? new CatchAndThrowMethodVisitor("java/lang/Throwable", instrumenter, withFrames)
-                : instrumenter;
+        return name.equals("<init>") ? instrumenter
+                : new CatchAndThrowMethodVisitor("java/lang/Throwable", instrumenter, withFrames);
     }
 
     @Override

--- a/ba-dua-tests/src/test/java/br/usp/each/saeg/badua/test/validation/ValidationTest.java
+++ b/ba-dua-tests/src/test/java/br/usp/each/saeg/badua/test/validation/ValidationTest.java
@@ -20,8 +20,6 @@ public abstract class ValidationTest {
 
     protected ValidationTestClassLoader loader;
 
-    protected boolean exceptionHandler = true;
-
     public void setUp() throws Exception {
         loader = new ValidationTestClassLoader();
     }
@@ -32,7 +30,7 @@ public abstract class ValidationTest {
 
     private byte[] instrument(final String name, final byte[] bytes) {
         final Instrumenter instrumenter = new Instrumenter(
-                new StaticAccessGenerator(RT.class.getName()), exceptionHandler);
+                new StaticAccessGenerator(RT.class.getName()));
 
         try {
             return instrumenter.instrument(bytes, name);


### PR DESCRIPTION
Remove the feature toggle "badua.experimental.exception_handler" and enables `CatchAndThrowMethodVisitor` by default.

Will also remove the constructors that was used to enable the exception handler feature on `Instrumenter` and on `ClassInstrumenter` classes.