### PR TITLE
Created ModifiedSystemClassRuntime implementation

### DIFF
--- a/ba-dua-agent-rt/pom.xml
+++ b/ba-dua-agent-rt/pom.xml
@@ -96,6 +96,7 @@
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 									<manifestEntries>
 										<Premain-Class>${badua.runtime.package.name}.PreMain</Premain-Class>
+										<Boot-Class-Path>${project.artifactId}-${project.version}-all.jar</Boot-Class-Path>
 									</manifestEntries>
 								</transformer>
 							</transformers>

--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
@@ -13,6 +13,7 @@ package br.usp.each.saeg.badua.agent.rt.internal;
 import java.lang.instrument.Instrumentation;
 
 import br.usp.each.saeg.badua.core.runtime.IRuntime;
+import br.usp.each.saeg.badua.core.runtime.ModifiedSystemClassRuntime;
 
 public final class PreMain {
 
@@ -20,8 +21,11 @@ public final class PreMain {
         // No instances
     }
 
-    public static void premain(final String opts, final Instrumentation inst) {
-        final IRuntime runtime = new RT();
+    public static void premain(final String opts, final Instrumentation inst) throws Exception {
+        final IRuntime runtime = Boolean.getBoolean("badua.experimental.ModifiedSystemClassRuntime")
+                ? ModifiedSystemClassRuntime.createFor(inst, "java/lang/UnknownError")
+                : new RT();
+
         runtime.startup(Agent.getInstance().getData());
         inst.addTransformer(new CoverageTransformer(runtime, PreMain.class.getPackage().getName()));
     }

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/InstrSupport.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/InstrSupport.java
@@ -14,6 +14,9 @@ import static java.lang.String.format;
 
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import br.usp.each.saeg.badua.core.runtime.RuntimeData;
 
 public final class InstrSupport {
 
@@ -21,9 +24,23 @@ public final class InstrSupport {
         // No instances
     }
 
+    public static final String RUNTIME_FIELD_NAME = "DATA";
+
+    public static final String RUNTIME_FIELD_DESC = Type.getDescriptor(RuntimeData.class);
+
+    public static final int RUNTIME_FIELD_ACC = Opcodes.ACC_SYNTHETIC |
+                                                Opcodes.ACC_PUBLIC |
+                                                Opcodes.ACC_STATIC |
+                                                Opcodes.ACC_TRANSIENT;
+
     public static final String RUNTIME_NAME = "getData";
 
     public static final String RUNTIME_DESC = "(JLjava/lang/String;I)[J";
+
+    public static final int RUNTIME_ACC = Opcodes.ACC_SYNTHETIC |
+                                          Opcodes.ACC_PUBLIC |
+                                          Opcodes.ACC_STATIC |
+                                          Opcodes.ACC_FINAL;
 
     // --- Data Field
 

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/IRuntime.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/IRuntime.java
@@ -12,6 +12,6 @@ package br.usp.each.saeg.badua.core.runtime;
 
 public interface IRuntime extends IExecutionDataAccessorGenerator {
 
-    void startup(RuntimeData data);
+    void startup(RuntimeData data) throws Exception;
 
 }

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/ModifiedSystemClassRuntime.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/ModifiedSystemClassRuntime.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2014, 2020 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.badua.core.runtime;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.lang.instrument.Instrumentation;
+import java.security.ProtectionDomain;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import br.usp.each.saeg.badua.core.internal.instr.InstrSupport;
+
+public class ModifiedSystemClassRuntime extends StaticAccessGenerator implements IRuntime {
+
+    private final Class<?> systemClass;
+
+    public ModifiedSystemClassRuntime(final Class<?> systemClass) {
+        super(systemClass.getName());
+        this.systemClass = systemClass;
+    }
+
+    @Override
+    public void startup(final RuntimeData data) throws Exception {
+        systemClass.getField(InstrSupport.RUNTIME_FIELD_NAME).set(null, data);
+    }
+
+    public static IRuntime createFor(final Instrumentation inst, final String forClassName)
+            throws ClassNotFoundException {
+
+        final ClassFileTransformer transformer = new ClassFileTransformer() {
+
+            @Override
+            public byte[] transform(final ClassLoader loader,
+                                    final String className,
+                                    final Class<?> classBeingRedefined,
+                                    final ProtectionDomain protectionDomain,
+                                    final byte[] classfileBuffer) throws IllegalClassFormatException {
+
+                if (className.equals(forClassName)) {
+                    return instrument(classfileBuffer);
+                }
+                return null;
+            }
+
+        };
+        inst.addTransformer(transformer);
+        final Class<?> clazz = Class.forName(forClassName.replace('/', '.'));
+        inst.removeTransformer(transformer);
+        try {
+            clazz.getField(InstrSupport.RUNTIME_FIELD_NAME);
+        } catch (final NoSuchFieldException e) {
+            throw new RuntimeException(String.format(
+                    "Class %s could not be instrumented.", forClassName), e);
+        }
+        return new ModifiedSystemClassRuntime(clazz);
+    }
+
+    private static byte[] instrument(final byte[] buffer) {
+        final ClassReader reader = new ClassReader(buffer);
+        final ClassWriter writer = new ClassWriter(reader, 0);
+        reader.accept(new ClassVisitor(Opcodes.ASM6, writer) {
+            @Override
+            public void visitEnd() {
+
+                final FieldVisitor fv = cv.visitField(
+                        InstrSupport.RUNTIME_FIELD_ACC,
+                        InstrSupport.RUNTIME_FIELD_NAME,
+                        InstrSupport.RUNTIME_FIELD_DESC,
+                        null, null);
+                fv.visitEnd();
+
+                final MethodVisitor mv = cv.visitMethod(
+                        InstrSupport.RUNTIME_ACC,
+                        InstrSupport.RUNTIME_NAME,
+                        InstrSupport.RUNTIME_DESC,
+                        null, null);
+                mv.visitCode();
+
+                mv.visitFieldInsn(Opcodes.GETSTATIC, reader.getClassName(),
+                        InstrSupport.RUNTIME_FIELD_NAME, InstrSupport.RUNTIME_FIELD_DESC);
+                mv.visitVarInsn(Opcodes.LLOAD, 0);
+                mv.visitVarInsn(Opcodes.ALOAD, 2);
+                mv.visitVarInsn(Opcodes.ILOAD, 3);
+                mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
+                        Type.getInternalName(RuntimeData.class),
+                        InstrSupport.RUNTIME_NAME,
+                        InstrSupport.RUNTIME_DESC,
+                        false);
+                mv.visitInsn(Opcodes.ARETURN);
+
+                mv.visitMaxs(5, 4);
+                mv.visitEnd();
+
+                super.visitEnd();
+            }
+        }, ClassReader.EXPAND_FRAMES);
+        return writer.toByteArray();
+    }
+
+}

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/RuntimeData.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/RuntimeData.java
@@ -45,4 +45,8 @@ public class RuntimeData {
         }
     }
 
+    public long[] getData(final long id, final String name, final int size) {
+        return getExecutionData(id, name, size).getData();
+    }
+
 }


### PR DESCRIPTION
This `IRuntime` implementation works with a modified system class.
New public static field and method are added to system class
`java.lang.UnknownError`. That will be used by instrumented classes.

As the system class itself needs to be instrumented this runtime
requires a Java agent.

The bytecode for the following code is added to the system class:

```java
/*synthetic*/ public static transient RuntimeData DATA;

/*synthetic*/ public static final long[] getData(
        long classId, String className, int size) {
    return DATA.getData(classId, className, size);
};
```

Instrumented classes will obtain the the execution data array by
calling this static method and therefore the runtime will extend
`StaticAccessGenerator`.

The field `DATA` is initialized with the runtime startup using
reflection.

This feature is disabled by default, to enable you must provide
a system property `-D<name>=<value>` with value `true` and name
`badua.experimental.ModifiedSystemClassRuntime`. Otherwise, the
default runtime `RT` will be used.

_Quoting JaCoCo documentation:_
> Making a runtime library available to all instrumented classes
> can be a painful or impossible task in frameworks that use their
> own class loading mechanisms.

The class `java.lang.UnknownError` is supposed to be loaded by
the bootstrap class loader and Java agent classes are provided
by the application class loader, therefore `RuntimeData` class
may not be visible to bootstrap class loader.

Fortunately, as our minimum target is Java 1.6, we have a way
to extend the bootstrap class loader.

_Quoting JaCoCo documentation:_
> Since Java 1.6 `java.lang.instrument.Instrumentation` has an API
> to extends the bootstrap loader.

An another way to extend the bootstrap class loader is by the
`Boot-Class-Path` agent JAR manifest attribute. We are using that.

This is different from what JaCoCo does, as they minimum target is
Java 1.5, JaCoCo decouples the instrumented classes and the coverage
runtime through official JRE API types only.

See JaCoCo's [Coverage Runtime Dependency](https://www.jacoco.org/jacoco/trunk/doc/implementation.html) documentation.

Our main use case is to support custom class loaders, in special
to Powermock testing tool. Our rational is that classes that should
be loaded by the bootstrap class loader will also load its class
dependencies with the bootstrap class loader.