### PR TITLE
Enable `ModifiedSystemClassRuntime` by default

### DIFF
--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
@@ -22,10 +22,8 @@ public final class PreMain {
     }
 
     public static void premain(final String opts, final Instrumentation inst) throws Exception {
-        final IRuntime runtime = Boolean.getBoolean("badua.experimental.ModifiedSystemClassRuntime")
-                ? ModifiedSystemClassRuntime.createFor(inst, "java/lang/UnknownError")
-                : new RT();
-
+        final IRuntime runtime = Boolean.getBoolean("badua.experimental.RT") ? new RT()
+                : ModifiedSystemClassRuntime.createFor(inst, "java/lang/UnknownError");
         runtime.startup(Agent.getInstance().getData());
         inst.addTransformer(new CoverageTransformer(runtime, PreMain.class.getPackage().getName()));
     }

--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/RT.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/RT.java
@@ -14,6 +14,7 @@ import br.usp.each.saeg.badua.core.runtime.IRuntime;
 import br.usp.each.saeg.badua.core.runtime.RuntimeData;
 import br.usp.each.saeg.badua.core.runtime.StaticAccessGenerator;
 
+@Deprecated
 public final class RT extends StaticAccessGenerator implements IRuntime {
 
     private static RuntimeData DATA;


### PR DESCRIPTION
Remove the feature toggle `badua.experimental.ModifiedSystemClassRuntime` and enables `ModifiedSystemClassRuntime` by default.

Deprecate `RT` runtime implementation and added a new feature toggle `badua.experimental.RT` to use this runtime.