### PR TITLE
Update GitHub Actions Setup Java SDK to version 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
+        distribution: zulu
         java-version: ${{ matrix.java }}
+        java-package: jdk
     - name: Java version
       run: java -version && javac -version
     - name: Build


### PR DESCRIPTION
Update from `actions/setup-java@v1` to `actions/setup-java@v2`

See: https://github.com/actions/setup-java/blob/v2.3.0/docs/switching-to-v2.md

We will keep using Zulu JDK distributions.