### PR TITLE
Created module `ba-dua-example`

### DIFF
--- a/ba-dua-example/.gitignore
+++ b/ba-dua-example/.gitignore
@@ -1,0 +1,12 @@
+*.class
+/target
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# eclipse
+/.classpath
+/.project
+/.settings

--- a/ba-dua-example/pom.xml
+++ b/ba-dua-example/pom.xml
@@ -1,0 +1,116 @@
+<!--
+
+    Copyright (c) 2014, 2020 University of Sao Paulo and Contributors.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Roberto Araujo - initial API and implementation and/or initial documentation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>br.usp.each.saeg</groupId>
+	<artifactId>ba-dua-example</artifactId>
+	<version>0.5.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>ba-dua-example</name>
+	<url>https://github.com/saeg/ba-dua</url>
+	<description>BA-DUA Example</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>${java.specification.version}</maven.compiler.source>
+		<maven.compiler.target>${java.specification.version}</maven.compiler.target>
+		<argLine>-javaagent:target/dependency/ba-dua-agent-rt-${project.version}-all.jar -Doutput.file=target/badua.ser</argLine>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>2.10</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>${project.groupId}</groupId>
+									<artifactId>ba-dua-agent-rt</artifactId>
+									<classifier>all</classifier>
+									<version>${project.version}</version>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.5.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>java</goal>
+						</goals>
+						<phase>verify</phase>
+						<configuration>
+							<mainClass>br.usp.each.saeg.badua.cli.Report</mainClass>
+							<arguments>
+								<argument>-input</argument>
+								<argument>${project.build.directory}/badua.ser</argument>
+								<argument>-classes</argument>
+								<argument>${project.build.outputDirectory}</argument>
+								<argument>-show-classes</argument>
+								<argument>-show-methods</argument>
+								<argument>-xml</argument>
+								<argument>${project.build.directory}/badua.xml</argument>
+							</arguments>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<!-- Using this version to support requireFileChecksum with Java 6 -->
+				<version>3.0.0-M1</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>verify</phase>
+						<configuration>
+							<rules>
+								<requireFileChecksum>
+									<file>${project.build.directory}/badua.xml</file>
+									<checksum>b481fddd94ffd06b62a1f717bdfa9f72</checksum>
+									<type>md5</type>
+								</requireFileChecksum>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>ba-dua-cli</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/ba-dua-example/src/main/java/br/usp/each/saeg/badua/example/ArraysUtil.java
+++ b/ba-dua-example/src/main/java/br/usp/each/saeg/badua/example/ArraysUtil.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2014, 2020 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.badua.example;
+
+public class ArraysUtil {
+
+    public static int max(final int[] array, final int length) {
+        int i = 0;
+        int max = array[i++];
+        while (i < length) {
+            if (array[i] > max) {
+                max = array[i];
+            }
+            i++;
+        }
+        return max;
+    }
+
+    public static void sort(final int[] a, final int n) {
+        int sortupto, maxpos, mymax, index;
+        sortupto = 0;
+        while (sortupto < n - 1) {
+            mymax = a[sortupto];
+            maxpos = sortupto;
+            index = sortupto + 1;
+            while (index < n) {
+                if (a[index] > mymax) {
+                    mymax = a[index];
+                    maxpos = index;
+                }
+                index++;
+            }
+            index = a[sortupto];
+            a[sortupto] = mymax;
+            a[maxpos] = index;
+            sortupto++;
+        }
+    }
+
+}

--- a/ba-dua-example/src/test/java/br/usp/each/saeg/badua/example/ArraysUtilTest.java
+++ b/ba-dua-example/src/test/java/br/usp/each/saeg/badua/example/ArraysUtilTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2014, 2020 University of Sao Paulo and Contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Roberto Araujo - initial API and implementation and/or initial documentation
+ */
+package br.usp.each.saeg.badua.example;
+
+import java.util.Arrays;
+
+public class ArraysUtilTest {
+
+    public void testMax() {
+        final int[] array = new int[] { 1, 2, 3, 2 };
+        assert 3 == ArraysUtil.max(array, array.length);
+    }
+
+    public void testSort() {
+        final int[] array = new int[] { 2, 3, 1 };
+        final int[] expected = new int[] { 3, 2, 1 };
+        ArraysUtil.sort(array, array.length);
+        assert Arrays.equals(expected, array);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
 		<module>ba-dua-cli</module>
 		<module>ba-dua-tests</module>
 		<module>ba-dua</module>
-		<module>ba-dua-example</module>
 	</modules>
 
 	<build>
@@ -264,6 +263,15 @@
 	</build>
 
 	<profiles>
+		<profile>
+			<id>example</id>
+			<activation>
+				<jdk>[1.6,9]</jdk>
+			</activation>
+			<modules>
+				<module>ba-dua-example</module>
+			</modules>
+		</profile>
 		<!-- http://openjdk.java.net/jeps/182 -->
 		<profile>
 			<id>jdk12</id>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
 		<module>ba-dua-cli</module>
 		<module>ba-dua-tests</module>
 		<module>ba-dua</module>
+		<module>ba-dua-example</module>
 	</modules>
 
 	<build>


### PR DESCRIPTION
This module contains only a single class with companion tests.
The tests are executed with BA-DUA agent and after tests execution
we generate XML coverage report and verify its contents are correct.

The idea is show how we can execute BA-DUA with Maven. We know that
current implementation is not production-ready, but will be useful
for testing BA-DUA builds with different JVMs.

*The implementation works as follow:*

We copy the BA-DUA agent using `maven-dependency-plugin` and execute
tests with the agent loaded through option `<argLine>` of
`maven-surefire-plugin`.

After tests execution we generate coverage report using BA-DUA CLI
with help of `exec-maven-plugin`. Finally, we verify that the XML
report is correct by matching the file checksum using
`maven-enforcer-plugin`.