### PR TITLE
Activate build of `ba-dua-example` with Java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
 		<profile>
 			<id>example</id>
 			<activation>
-				<jdk>[1.6,9]</jdk>
+				<jdk>[1.6,10)</jdk>
 			</activation>
 			<modules>
 				<module>ba-dua-example</module>


### PR DESCRIPTION
On PR #22 (20f2dfe) I wrongly didn't activate build of module
`ba-dua-example` for all Java 9 versions.

See that Java 9 builds does not include module `ba-dua-example`
* [Windows](https://github.com/saeg/ba-dua/runs/3628430481)
* [Linux](https://github.com/saeg/ba-dua/runs/3628430233)

(I hope GitHub keep these links in the future)

Quoting Maven documentation:
> an upper bound such as `,1.5]` is likely not to include most releases of
> 1.5, since they will have an additional "patch" release such as `_05`
> that is not taken into consideration in the above range.

This commit fix the supported version range.