### PR TITLE
Update ASM API to version 9 and official support Java from 10 to 17

### DIFF
--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/analysis/ClassAnalyzer.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/analysis/ClassAnalyzer.java
@@ -53,7 +53,7 @@ public class ClassAnalyzer extends ClassVisitor {
     private int window;
 
     public ClassAnalyzer(final ExecutionData execData, final StringPool stringPool) {
-        super(Opcodes.ASM6);
+        super(Opcodes.ASM9);
         this.execData = execData;
         this.stringPool = stringPool;
     }
@@ -105,7 +105,7 @@ public class ClassAnalyzer extends ClassVisitor {
         else if (name.equals("<clinit>"))
             return null;
 
-        return new MethodNode(Opcodes.ASM6, access, name, desc, signature, exceptions) {
+        return new MethodNode(Opcodes.ASM9, access, name, desc, signature, exceptions) {
 
             @Override
             public void visitEnd() {

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/CatchAndThrowMethodVisitor.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/CatchAndThrowMethodVisitor.java
@@ -33,7 +33,7 @@ public class CatchAndThrowMethodVisitor extends MethodVisitor {
     private boolean started;
 
     public CatchAndThrowMethodVisitor(final String type, final MethodNode mn, final boolean withFrames) {
-        super(Opcodes.ASM6, mn);
+        super(Opcodes.ASM9, mn);
         this.type = type;
         this.withFrames = withFrames;
     }

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/ClassInstrumenter.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/ClassInstrumenter.java
@@ -35,7 +35,7 @@ public class ClassInstrumenter extends ClassVisitor implements IdGenerator {
     public ClassInstrumenter(final long classId, final ClassVisitor cv,
             final IExecutionDataAccessorGenerator accessorGenerator) {
 
-        super(Opcodes.ASM6, cv);
+        super(Opcodes.ASM9, cv);
         this.classId = classId;
         this.accessorGenerator = accessorGenerator;
     }

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/MethodInstrumenter.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/internal/instr/MethodInstrumenter.java
@@ -33,7 +33,7 @@ public class MethodInstrumenter extends MethodNode {
                               final MethodVisitor next,
                               final MethodTransformer mt) {
 
-        super(Opcodes.ASM6, access, name, desc, signature, exceptions);
+        super(Opcodes.ASM9, access, name, desc, signature, exceptions);
         this.exceptions = exceptions;
         this.next = next;
         this.mt = mt;

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/ModifiedSystemClassRuntime.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/runtime/ModifiedSystemClassRuntime.java
@@ -73,7 +73,7 @@ public class ModifiedSystemClassRuntime extends StaticAccessGenerator implements
     private static byte[] instrument(final byte[] buffer) {
         final ClassReader reader = new ClassReader(buffer);
         final ClassWriter writer = new ClassWriter(reader, 0);
-        reader.accept(new ClassVisitor(Opcodes.ASM6, writer) {
+        reader.accept(new ClassVisitor(Opcodes.ASM9, writer) {
             @Override
             public void visitEnd() {
 


### PR DESCRIPTION
PR #24 (d396cb9) updated ASM-DefUse library to version 0.0.7 and the
transitive dependency ASM from version 6.0 to version 9.2. There we also
started building the module `ba-dua-example` for any Java >= 6

This commit update the ASM API constant from ASM6 to ASM9 so we can
support newer Bytecode features.