### PR TITLE
Remove `instrument(ClassReader)` and `analyze(ClassReader)`

### DIFF
--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/analysis/Analyzer.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/analysis/Analyzer.java
@@ -20,6 +20,7 @@ import br.usp.each.saeg.badua.core.data.ExecutionData;
 import br.usp.each.saeg.badua.core.data.ExecutionDataStore;
 import br.usp.each.saeg.badua.core.internal.ContentTypeDetector;
 import br.usp.each.saeg.badua.core.internal.data.CRC64;
+import br.usp.each.saeg.commons.io.Files;
 
 public class Analyzer {
 
@@ -45,8 +46,9 @@ public class Analyzer {
         return new ExecutionData(classId, className, null);
     }
 
-    public void analyze(final ClassReader reader) {
-        final long classId = CRC64.checksum(reader.b);
+    public void analyze(final byte[] buffer) {
+        final long classId = CRC64.checksum(buffer);
+        final ClassReader reader = new ClassReader(buffer);
         final ClassAnalyzer ca = new ClassAnalyzer(getData(classId, reader.getClassName()), stringPool);
         reader.accept(ca, DEFAULT);
         final ClassCoverage coverage = ca.getCoverage();
@@ -57,7 +59,7 @@ public class Analyzer {
 
     public void analyze(final InputStream input, final String location) throws IOException {
         try {
-            analyze(new ClassReader(input));
+            analyze(Files.toByteArray(input));
         } catch (final RuntimeException e) {
             throw analyzeError(location, e);
         }

--- a/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/instr/Instrumenter.java
+++ b/ba-dua-core/src/main/java/br/usp/each/saeg/badua/core/instr/Instrumenter.java
@@ -34,8 +34,9 @@ public class Instrumenter {
         this.accessorGenerator = accessorGenerator;
     }
 
-    public byte[] instrument(final ClassReader reader) {
-        final long classId = CRC64.checksum(reader.b);
+    public byte[] instrument(final byte[] buffer) {
+        final long classId = CRC64.checksum(buffer);
+        final ClassReader reader = new ClassReader(buffer);
         final ClassWriter writer = new ClassWriter(reader, DEFAULT);
         final ClassVisitor ci = new ClassInstrumenter(classId, writer, accessorGenerator);
         reader.accept(ci, ClassReader.EXPAND_FRAMES);
@@ -44,7 +45,7 @@ public class Instrumenter {
 
     public byte[] instrument(final byte[] buffer, final String name) throws IOException {
         try {
-            return instrument(new ClassReader(buffer));
+            return instrument(buffer);
         } catch (final RuntimeException e) {
             throw instrumentError(name, e);
         }
@@ -53,7 +54,7 @@ public class Instrumenter {
     public void instrument(final InputStream input, final OutputStream output, final String name)
             throws IOException {
         try {
-            output.write(instrument(new ClassReader(input)));
+            output.write(instrument(Files.toByteArray(input)));
         } catch (final RuntimeException e) {
             throw instrumentError(name, e);
         }

--- a/ba-dua-tests/src/test/java/br/usp/each/saeg/badua/test/validation/ValidationTargetsTest.java
+++ b/ba-dua-tests/src/test/java/br/usp/each/saeg/badua/test/validation/ValidationTargetsTest.java
@@ -17,7 +17,6 @@ import java.util.Collection;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.objectweb.asm.ClassReader;
 
 import br.usp.each.saeg.badua.core.analysis.Analyzer;
 import br.usp.each.saeg.badua.core.analysis.ClassCoverage;
@@ -47,7 +46,7 @@ public abstract class ValidationTargetsTest extends ValidationTest implements IC
         final byte[] bytes = ValidationTestClassLoader.getClassDataAsBytes(target);
         final ExecutionDataStore store = execute(bytes);
         final Analyzer analyzer = new Analyzer(store, this);
-        analyzer.analyze(new ClassReader(bytes));
+        analyzer.analyze(bytes);
         Assert.assertEquals(1, classes.size());
         for (final MethodCoverage coverage : classes.iterator().next().getMethods()) {
             defUses.addAll(coverage.getDefUses());


### PR DESCRIPTION
These methods use the field `ClassReader.b` which is marked as deprecated.

Also there is others issues when using `ClassReader` as API for these methods.

See reference: https://github.com/jacoco/jacoco/pull/850

This commit introduce new methods that reads the byte array `byte[]` directly.