### PR TITLE
Update ASM-DefUse to version 0.0.8

### DIFF
--- a/ba-dua-core/pom.xml
+++ b/ba-dua-core/pom.xml
@@ -51,12 +51,12 @@
 		<dependency>
 			<groupId>br.usp.each.saeg</groupId>
 			<artifactId>asm-defuse</artifactId>
-			<version>0.0.7</version>
+			<version>0.0.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm-commons</artifactId>
-			<version>9.2</version>
+			<version>9.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jacoco</groupId>


### PR DESCRIPTION
This version is based on ASM 9.3. In theory, it will introduce BA-DUA
support up to Java 19 classes.

This commit will also update ASM Commons to respective version 9.3 so
all ASM transitive dependencies will also be in version 9.3.