### PR TITLE
Extend bootstrap class loader using Instrumentation API

### DIFF
--- a/ba-dua-agent-rt/pom.xml
+++ b/ba-dua-agent-rt/pom.xml
@@ -96,7 +96,6 @@
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 									<manifestEntries>
 										<Premain-Class>${badua.runtime.package.name}.PreMain</Premain-Class>
-										<Boot-Class-Path>${project.artifactId}-${project.version}-all.jar</Boot-Class-Path>
 									</manifestEntries>
 								</transformer>
 							</transformers>

--- a/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
+++ b/ba-dua-agent-rt/src/main/java/br/usp/each/saeg/badua/agent/rt/internal/PreMain.java
@@ -11,7 +11,10 @@
 package br.usp.each.saeg.badua.agent.rt.internal;
 
 import java.lang.instrument.Instrumentation;
+import java.security.CodeSource;
+import java.util.jar.JarFile;
 
+import br.usp.each.saeg.badua.core.runtime.IExecutionDataAccessorGenerator;
 import br.usp.each.saeg.badua.core.runtime.IRuntime;
 import br.usp.each.saeg.badua.core.runtime.ModifiedSystemClassRuntime;
 
@@ -22,9 +25,31 @@ public final class PreMain {
     }
 
     public static void premain(final String opts, final Instrumentation inst) throws Exception {
-        final IRuntime runtime = ModifiedSystemClassRuntime.createFor(inst, "java/lang/UnknownError");
-        runtime.startup(Agent.getInstance().getData());
-        inst.addTransformer(new CoverageTransformer(runtime, PreMain.class.getPackage().getName()));
+        final CodeSource codeSource = PreMain.class.getProtectionDomain().getCodeSource();
+        inst.appendToBootstrapClassLoaderSearch(new JarFile(codeSource.getLocation().getPath()));
+
+        Init.init(inst);
+    }
+
+    /**
+     *
+     * I don't know if this is the correct way to avoid LinkageError.
+     *
+     * If code is in same method {@link IExecutionDataAccessorGenerator}
+     * will be loaded by the application class loader before it was
+     * appended to bootstrap class loader. So a LinkageError will be
+     * thrown as we expect a class loaded by the bootstrap class loader.
+     *
+     * Since everything is in a method from another class it doesn't
+     * happen. But again, IDK if this is the correct approach.
+     *
+     */
+    public static class Init {
+        public static void init(final Instrumentation inst) throws Exception {
+            final IRuntime runtime = ModifiedSystemClassRuntime.createFor(inst, "java/lang/UnknownError");
+            runtime.startup(Agent.getInstance().getData());
+            inst.addTransformer(new CoverageTransformer(runtime, PreMain.class.getPackage().getName()));
+        }
     }
 
 }


### PR DESCRIPTION
We need to extend the bootstrap class loader to use the BA-DUA agent. We
used the `Boot-Class-Path` manifest attributes to achieve that, but this
has a drawback: the manifest attributes are constant values. The file
name will need to be the same as the `Boot-Class-Path` manifest
attribute.

See: issue #28

See: https://docs.oracle.com/javase/6/docs/api/java/lang/instrument/package-summary.html

With these changes, we start using the Instrumentation API to append JAR
files to the bootstrap class loader, allowing us to programmatically
extend the bootstrap class loader.

See: https://docs.oracle.com/javase/6/docs/api/java/lang/instrument/Instrumentation.html

There is a hacky workaround that was needed to avoid `LinkageError`. See
code comments for a better understanding.

Without this hacky workaround, the agent throws an exception like the
following:

```
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:386)
	at sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:401)
Caused by: java.lang.LinkageError: loader constraint violation: when resolving method "br.usp.each.saeg.badua.agent.rt.internal_4ad1841.CoverageTransformer.<init>(Lbr/usp/each/saeg/badua/agent/rt/internal_4ad1841/core/runtime/IExecutionDataAccessorGenerator;Ljava/lang/String;)V" the class loader (instance of sun/misc/Launcher$AppClassLoader) of the current class, br/usp/each/saeg/badua/agent/rt/internal_4ad1841/PreMain, and the class loader (instance of <bootloader>) for the method's defining class, br/usp/each/saeg/badua/agent/rt/internal_4ad1841/CoverageTransformer, have different Class objects for the type br/usp/each/saeg/badua/agent/rt/internal_4ad1841/core/runtime/IExecutionDataAccessorGenerator used in the signature
	at br.usp.each.saeg.badua.agent.rt.internal_4ad1841.PreMain.premain(PreMain.java:33)
	... 6 more
```

fixes #28